### PR TITLE
adds the possibility to start the list and maps expanded or collapsed

### DIFF
--- a/lib/src/builders/primitive_builders/list_builder.dart
+++ b/lib/src/builders/primitive_builders/list_builder.dart
@@ -4,11 +4,7 @@ import 'package:flutter_json_view/src/utils/typer.dart';
 import 'package:flutter_json_view/src/widgets/widgets.dart';
 
 class JsonListBuilder extends StatefulWidget {
-  const JsonListBuilder({
-    Key? key,
-    required this.jsonObj,
-    required this.jsonViewTheme,
-  }) : super(key: key);
+  const JsonListBuilder({Key? key, required this.jsonObj, required this.jsonViewTheme}) : super(key: key);
 
   final List jsonObj;
   final JsonViewTheme jsonViewTheme;
@@ -18,7 +14,13 @@ class JsonListBuilder extends StatefulWidget {
 }
 
 class _JsonListBuilderState extends State<JsonListBuilder> {
-  bool isOpened = true;
+  late bool isOpened;
+
+  @override
+  void initState() {
+    isOpened = widget.jsonViewTheme.listInitialExpanded;
+    super.initState();
+  }
 
   @override
   Widget build(BuildContext context) {
@@ -28,9 +30,7 @@ class _JsonListBuilderState extends State<JsonListBuilder> {
       children: [
         GestureDetector(
           onTap: () => setState(() => isOpened = !isOpened),
-          child: isOpened
-              ? widget.jsonViewTheme.closeIcon
-              : widget.jsonViewTheme.openIcon,
+          child: isOpened ? widget.jsonViewTheme.closeIcon : widget.jsonViewTheme.openIcon,
         ),
         _buildItem(items),
       ],
@@ -43,8 +43,7 @@ class _JsonListBuilderState extends State<JsonListBuilder> {
         isList: true,
         jsonViewTheme: widget.jsonViewTheme,
         count: widget.jsonObj.length,
-        type: Typer.getType(
-            widget.jsonObj.isNotEmpty ? widget.jsonObj.first : null),
+        type: Typer.getType(widget.jsonObj.isNotEmpty ? widget.jsonObj.first : null),
       );
     }
     return Column(

--- a/lib/src/builders/primitive_builders/map_builder.dart
+++ b/lib/src/builders/primitive_builders/map_builder.dart
@@ -17,7 +17,13 @@ class JsonMapBuilder extends StatefulWidget {
 }
 
 class _JsonMapBuilderState extends State<JsonMapBuilder> {
-  bool isOpened = true;
+  late bool isOpened;
+
+  @override
+  void initState() {
+    isOpened = widget.jsonViewTheme.mapInitialExpanded;
+    super.initState();
+  }
 
   @override
   Widget build(BuildContext context) {
@@ -26,9 +32,7 @@ class _JsonMapBuilderState extends State<JsonMapBuilder> {
       children: [
         GestureDetector(
           onTap: () => setState(() => isOpened = !isOpened),
-          child: isOpened
-              ? widget.jsonViewTheme.closeIcon
-              : widget.jsonViewTheme.openIcon,
+          child: isOpened ? widget.jsonViewTheme.closeIcon : widget.jsonViewTheme.openIcon,
         ),
         _buidItem(),
       ],

--- a/lib/src/theme/json_view_theme.dart
+++ b/lib/src/theme/json_view_theme.dart
@@ -35,6 +35,8 @@ class JsonViewTheme {
     this.loadingWidget = const CircularProgressIndicator(),
     this.viewType = JsonViewType.collapsible,
     this.backgroundColor = const Color(0xFF1E1F28),
+    this.listInitialExpanded = true,
+    this.mapInitialExpanded = true,
   })  : _keyStyle = keyStyle ?? const TextStyle(color: Colors.deepPurple),
         _doubleStyle = doubleStyle ?? const TextStyle(color: Colors.blue),
         _intStyle = intStyle ?? const TextStyle(color: Colors.blue),
@@ -95,4 +97,12 @@ class JsonViewTheme {
   /// This style used as default for all styles
   /// and for not parsed values
   final TextStyle defaultTextStyle;
+
+  /// Set if the lists should show
+  /// collapsed or expanded on its first render.
+  final bool listInitialExpanded;
+
+  /// Set if the maps should show
+  /// collapsed or expanded on its first render.
+  final bool mapInitialExpanded;
 }


### PR DESCRIPTION
Thanks for creating this great library!

I was missing the possibility to set the initial expand/collapse state, which is especially helpful with very large Json files.
So I added two options to JsonViewTheme.
- listInitialExpanded (default true)
- mapInitialExpanded (default true)

