### PR TITLE
Added ability to replace JsonView with Error widget

### DIFF
--- a/example/lib/examples/github_user.dart
+++ b/example/lib/examples/github_user.dart
@@ -18,7 +18,10 @@ class JsonViewApp extends StatelessWidget {
         appBar: AppBar(title: Text('flutter_json_view 1.1.2')),
         body: Padding(
           padding: const EdgeInsets.all(10),
-          child: JsonView.asset('assets/github_user.json'),
+          child: JsonView.asset(
+            'assets/github_user.json',
+            onError: const Text("Failed to load Asset"),
+          ),
         ),
       ),
     );

--- a/example/lib/examples/green_custom.dart
+++ b/example/lib/examples/green_custom.dart
@@ -89,6 +89,7 @@ class JsonViewApp extends StatelessWidget {
                 ),
               ),
             ),
+            onError: const Text("Failed to parse String"),
           ),
         ),
       ),

--- a/example/lib/examples/map.dart
+++ b/example/lib/examples/map.dart
@@ -29,6 +29,7 @@ class JsonViewApp extends StatelessWidget {
                 'height': 186.5
               },
             },
+            onError: Text("Failed to parse map"),
           ),
         ),
       ),

--- a/example/lib/examples/pink.dart
+++ b/example/lib/examples/pink.dart
@@ -36,6 +36,7 @@ class JsonViewApp extends StatelessWidget {
                 color: Colors.purple,
               ),
             ),
+            onError: const Text("Failed to parse String"),
           ),
         ),
       ),

--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -45,6 +45,7 @@ class _HomeScreenState extends State<_HomeScreen> {
               JsonView.string(
                 '{"author":{"name": "Stas", "lastName": "Ilin", "githubLogin": "Frezyx", "age": 19, "man": true, "height": 186.5}}',
                 theme: const JsonViewTheme(viewType: JsonViewType.collapsible),
+                onError: const Text("Failed to parse String"),
               ),
               const SizedBox(height: 10),
               Text('Base', style: theme.textTheme.headlineSmall),
@@ -52,6 +53,7 @@ class _HomeScreenState extends State<_HomeScreen> {
               JsonView.string(
                 '{"author":{"name": "Stas", "lastName": "Ilin", "githubLogin": "Frezyx", "age": 19, "man": true, "height": 186.5}}',
                 theme: const JsonViewTheme(viewType: JsonViewType.base),
+                onError: const Text("Failed to parse String"),
               ),
               const SizedBox(height: 10),
               Text('Big data', style: theme.textTheme.headlineSmall),
@@ -62,6 +64,7 @@ class _HomeScreenState extends State<_HomeScreen> {
                   'assets/github_user.json',
                   theme:
                       const JsonViewTheme(viewType: JsonViewType.collapsible),
+                  onError: const Text("Failed to parse JSON"),
                 ),
               ),
             ],

--- a/lib/src/builders/asset_json_view_builder.dart
+++ b/lib/src/builders/asset_json_view_builder.dart
@@ -5,16 +5,18 @@ import 'package:flutter_json_view/src/widgets/widgets.dart';
 import 'builders.dart';
 
 class AssetJsonViewBuilder implements JsonViewBuilder {
-  AssetJsonViewBuilder(this.path, {JsonViewTheme? jsonViewTheme})
+  AssetJsonViewBuilder(this.path, this.onError, {JsonViewTheme? jsonViewTheme})
       : _jsonViewTheme = jsonViewTheme ?? const JsonViewTheme();
 
   final String path;
+  final dynamic onError;
   final JsonViewTheme _jsonViewTheme;
 
   @override
   Widget build() {
     return JsonLoaderItem(
       path: path,
+      onError: onError,
       jsonViewTheme: _jsonViewTheme,
     );
   }

--- a/lib/src/builders/common_json_view_builder.dart
+++ b/lib/src/builders/common_json_view_builder.dart
@@ -10,6 +10,7 @@ class CommonJsonViewBuilder implements JsonViewBuilder {
       : _jsonViewTheme = jsonViewTheme;
 
   final dynamic jsonObj;
+
   final JsonViewTheme _jsonViewTheme;
 
   @override
@@ -31,7 +32,10 @@ class CommonJsonViewBuilder implements JsonViewBuilder {
         jsonObj: jsonObj as List,
         jsonViewTheme: _jsonViewTheme,
       );
+    } else if (jsonObj is Widget) {
+      return jsonObj;
     }
+    ;
     return PrimitiveBuilder(
       jsonObj,
       jsonViewTheme: _jsonViewTheme,

--- a/lib/src/builders/map_json_view_builder.dart
+++ b/lib/src/builders/map_json_view_builder.dart
@@ -4,13 +4,14 @@ import 'package:flutter_json_view/src/theme/json_view_theme.dart';
 import 'builders.dart';
 
 class MapJsonViewBuilder implements JsonViewBuilder {
-  MapJsonViewBuilder(this.map, {JsonViewTheme? jsonViewTheme})
+  MapJsonViewBuilder(this.map, this.onError, {JsonViewTheme? jsonViewTheme})
       : _commonBuilder = CommonJsonViewBuilder(
           map,
           jsonViewTheme: jsonViewTheme ?? const JsonViewTheme(),
         );
 
   final Map<String, dynamic> map;
+  final dynamic onError;
   final JsonViewBuilder _commonBuilder;
 
   @override

--- a/lib/src/builders/string_json_view_builder.dart
+++ b/lib/src/builders/string_json_view_builder.dart
@@ -5,13 +5,15 @@ import 'package:flutter_json_view/src/utils/utils.dart';
 import 'builders.dart';
 
 class StringJsonViewBuilder implements JsonViewBuilder {
-  StringJsonViewBuilder(this.jsonString, {JsonViewTheme? jsonViewTheme})
+  StringJsonViewBuilder(this.jsonString, this.onError,
+      {JsonViewTheme? jsonViewTheme})
       : _commonBuilder = CommonJsonViewBuilder(
-          JsonConverter.jsonStringToObject(jsonString),
+          JsonConverter.jsonStringToObject(jsonString, onError),
           jsonViewTheme: jsonViewTheme ?? const JsonViewTheme(),
         );
 
   final String jsonString;
+  final dynamic onError;
   final JsonViewBuilder _commonBuilder;
 
   @override

--- a/lib/src/flutter_json_view.dart
+++ b/lib/src/flutter_json_view.dart
@@ -14,12 +14,15 @@ class JsonView extends StatefulWidget {
   JsonView.string(
     String jsonString, {
     Key? key,
+    required Widget onError,
     JsonViewTheme? theme,
   })  : _stringData = jsonString,
         _mapData = null,
         _assetsPath = null,
+        _onError = onError,
         _builder = StringJsonViewBuilder(
           jsonString,
+          onError,
           jsonViewTheme: theme,
         ),
         super(key: key);
@@ -32,12 +35,15 @@ class JsonView extends StatefulWidget {
   JsonView.asset(
     String path, {
     Key? key,
+    required Widget onError,
     JsonViewTheme? theme,
   })  : _assetsPath = path,
         _mapData = null,
         _stringData = null,
+        _onError = onError,
         _builder = AssetJsonViewBuilder(
           path,
+          onError,
           jsonViewTheme: theme,
         ),
         super(key: key);
@@ -47,12 +53,15 @@ class JsonView extends StatefulWidget {
   JsonView.map(
     Map<String, dynamic> map, {
     Key? key,
+    required Widget onError,
     JsonViewTheme? theme,
   })  : _mapData = map,
         _stringData = null,
         _assetsPath = null,
+        _onError = onError,
         _builder = MapJsonViewBuilder(
           map,
+          onError,
           jsonViewTheme: theme,
         ),
         super(key: key);
@@ -60,6 +69,7 @@ class JsonView extends StatefulWidget {
   final Map<String, dynamic>? _mapData;
   final String? _stringData;
   final String? _assetsPath;
+  final Widget _onError;
   final JsonViewBuilder _builder;
   static PrimitiveJsonItemBuilder? primitiveJsonItemBuilder;
 
@@ -82,6 +92,7 @@ class _JsonViewState extends State<JsonView> {
         jsonView = BaseJsonView(
           jsonData: jsonData,
           assetsPath: widget._assetsPath,
+          onError: widget._onError,
           jsonViewTheme: widget._builder.jsonViewTheme,
         );
         break;

--- a/lib/src/utils/asset_loader.dart
+++ b/lib/src/utils/asset_loader.dart
@@ -6,8 +6,8 @@ abstract class AssetLoader {
     return rootBundle.loadString(path);
   }
 
-  static Future<dynamic> getAssetJson(String filePath) async {
+  static Future<dynamic> getAssetJson(String filePath, onError) async {
     final jsonString = await _loadAssets(filePath);
-    return JsonConverter.jsonStringToObject(jsonString);
+    return JsonConverter.jsonStringToObject(jsonString, onError);
   }
 }

--- a/lib/src/utils/converter.dart
+++ b/lib/src/utils/converter.dart
@@ -1,9 +1,12 @@
 import 'dart:convert';
 
 abstract class JsonConverter {
-  static dynamic jsonStringToObject(String jsonString) {
-    assert(canConverToObject(jsonString));
-    return json.decode(jsonString);
+  static dynamic jsonStringToObject(String jsonString, dynamic onError) {
+    try {
+      return json.decode(jsonString);
+    } catch (_) {
+      return onError;
+    }
   }
 
   static bool canConverToObject(String jsonString) {

--- a/lib/src/widgets/base_json_view.dart
+++ b/lib/src/widgets/base_json_view.dart
@@ -9,10 +9,12 @@ class BaseJsonView extends StatefulWidget {
     Key? key,
     required this.jsonViewTheme,
     this.jsonData,
+    required this.onError,
     this.assetsPath,
   }) : super(key: key);
 
   final String? jsonData;
+  final Widget onError;
   final JsonViewTheme jsonViewTheme;
   final String? assetsPath;
 
@@ -31,7 +33,8 @@ class _BaseJsonViewState extends State<BaseJsonView> {
 
   Future<void> _loadAssetsJson() async {
     if (widget.assetsPath != null) {
-      final json = await AssetLoader.getAssetJson(widget.assetsPath!);
+      final json =
+          await AssetLoader.getAssetJson(widget.assetsPath!, widget.onError);
       _assetsJsonString = _encoder.convert(json);
       setState(() {});
     }

--- a/lib/src/widgets/json_loader_item.dart
+++ b/lib/src/widgets/json_loader_item.dart
@@ -7,10 +7,12 @@ class JsonLoaderItem extends StatefulWidget {
   const JsonLoaderItem({
     Key? key,
     required this.path,
+    required this.onError,
     required this.jsonViewTheme,
   }) : super(key: key);
   final String path;
   final JsonViewTheme jsonViewTheme;
+  final Widget onError;
 
   @override
   State<JsonLoaderItem> createState() => _JsonLoaderItemState();
@@ -31,7 +33,7 @@ class _JsonLoaderItemState extends State<JsonLoaderItem> {
   }
 
   Future<void> _initializeBuilder() async {
-    final json = await AssetLoader.getAssetJson(widget.path);
+    final json = await AssetLoader.getAssetJson(widget.path, widget.onError);
     setState(() {
       _commonBuilder = CommonJsonViewBuilder(
         json,

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -37,10 +37,10 @@ packages:
     dependency: transitive
     description:
       name: collection
-      sha256: f092b211a4319e98e5ff58223576de6c2803db36221657b46c82574721240687
+      sha256: ee67cb0715911d28db6bf4af1026078bd6f0128b07a5f66fb2ed94ec6783c09a
       url: "https://pub.dev"
     source: hosted
-    version: "1.17.2"
+    version: "1.18.0"
   fake_async:
     dependency: transitive
     description:
@@ -58,55 +58,79 @@ packages:
     dependency: "direct main"
     description:
       name: flutter_lints
-      sha256: "2118df84ef0c3ca93f96123a616ae8540879991b8b57af2f81b76a7ada49b2a4"
+      sha256: "9e8c3858111da373efc5aa341de011d9bd23e2c5c5e0c62bccf32438e192d7b1"
       url: "https://pub.dev"
     source: hosted
-    version: "2.0.2"
+    version: "3.0.2"
   flutter_test:
     dependency: "direct dev"
     description: flutter
     source: sdk
     version: "0.0.0"
+  leak_tracker:
+    dependency: transitive
+    description:
+      name: leak_tracker
+      sha256: "3f87a60e8c63aecc975dda1ceedbc8f24de75f09e4856ea27daf8958f2f0ce05"
+      url: "https://pub.dev"
+    source: hosted
+    version: "10.0.5"
+  leak_tracker_flutter_testing:
+    dependency: transitive
+    description:
+      name: leak_tracker_flutter_testing
+      sha256: "932549fb305594d82d7183ecd9fa93463e9914e1b67cacc34bc40906594a1806"
+      url: "https://pub.dev"
+    source: hosted
+    version: "3.0.5"
+  leak_tracker_testing:
+    dependency: transitive
+    description:
+      name: leak_tracker_testing
+      sha256: "6ba465d5d76e67ddf503e1161d1f4a6bc42306f9d66ca1e8f079a47290fb06d3"
+      url: "https://pub.dev"
+    source: hosted
+    version: "3.0.1"
   lints:
     dependency: transitive
     description:
       name: lints
-      sha256: "0a217c6c989d21039f1498c3ed9f3ed71b354e69873f13a8dfc3c9fe76f1b452"
+      sha256: cbf8d4b858bb0134ef3ef87841abdf8d63bfc255c266b7bf6b39daa1085c4290
       url: "https://pub.dev"
     source: hosted
-    version: "2.1.1"
+    version: "3.0.0"
   matcher:
     dependency: transitive
     description:
       name: matcher
-      sha256: "1803e76e6653768d64ed8ff2e1e67bea3ad4b923eb5c56a295c3e634bad5960e"
+      sha256: d2323aa2060500f906aa31a895b4030b6da3ebdcc5619d14ce1aada65cd161cb
       url: "https://pub.dev"
     source: hosted
-    version: "0.12.16"
+    version: "0.12.16+1"
   material_color_utilities:
     dependency: transitive
     description:
       name: material_color_utilities
-      sha256: "9528f2f296073ff54cb9fee677df673ace1218163c3bc7628093e7eed5203d41"
+      sha256: f7142bb1154231d7ea5f96bc7bde4bda2a0945d2806bb11670e30b850d56bdec
       url: "https://pub.dev"
     source: hosted
-    version: "0.5.0"
+    version: "0.11.1"
   meta:
     dependency: transitive
     description:
       name: meta
-      sha256: "3c74dbf8763d36539f114c799d8a2d87343b5067e9d796ca22b5eb8437090ee3"
+      sha256: "7687075e408b093f36e6bbf6c91878cc0d4cd10f409506f7bc996f68220b9136"
       url: "https://pub.dev"
     source: hosted
-    version: "1.9.1"
+    version: "1.12.0"
   path:
     dependency: transitive
     description:
       name: path
-      sha256: "8829d8a55c13fc0e37127c29fedf290c102f4e40ae94ada574091fe0ff96c917"
+      sha256: "087ce49c3f0dc39180befefc60fdb4acd8f8620e5682fe2476afd0b3688bb4af"
       url: "https://pub.dev"
     source: hosted
-    version: "1.8.3"
+    version: "1.9.0"
   sky_engine:
     dependency: transitive
     description: flutter
@@ -124,18 +148,18 @@ packages:
     dependency: transitive
     description:
       name: stack_trace
-      sha256: c3c7d8edb15bee7f0f74debd4b9c5f3c2ea86766fe4178eb2a18eb30a0bdaed5
+      sha256: "73713990125a6d93122541237550ee3352a2d84baad52d375a4cad2eb9b7ce0b"
       url: "https://pub.dev"
     source: hosted
-    version: "1.11.0"
+    version: "1.11.1"
   stream_channel:
     dependency: transitive
     description:
       name: stream_channel
-      sha256: "83615bee9045c1d322bbbd1ba209b7a749c2cbcdcb3fdd1df8eb488b3279c1c8"
+      sha256: ba2aa5d8cc609d96bbb2899c28934f9e1af5cddbd60a827822ea467161eb54e7
       url: "https://pub.dev"
     source: hosted
-    version: "2.1.1"
+    version: "2.1.2"
   string_scanner:
     dependency: transitive
     description:
@@ -156,10 +180,10 @@ packages:
     dependency: transitive
     description:
       name: test_api
-      sha256: "75760ffd7786fffdfb9597c35c5b27eaeec82be8edfb6d71d32651128ed7aab8"
+      sha256: "9955ae474176f7ac8ee4e989dadfb411a58c30415bcfb648fa04b2b8a03afa7f"
       url: "https://pub.dev"
     source: hosted
-    version: "0.6.0"
+    version: "0.7.0"
   vector_math:
     dependency: transitive
     description:
@@ -168,14 +192,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "2.1.4"
-  web:
+  vm_service:
     dependency: transitive
     description:
-      name: web
-      sha256: dc8ccd225a2005c1be616fe02951e2e342092edf968cf0844220383757ef8f10
+      name: vm_service
+      sha256: a75f83f14ad81d5fe4b3319710b90dec37da0e22612326b696c9e1b8f34bbf48
       url: "https://pub.dev"
     source: hosted
-    version: "0.1.4-beta"
+    version: "14.2.0"
 sdks:
-  dart: ">=3.1.0-185.0.dev <4.0.0"
-  flutter: ">=1.17.0"
+  dart: ">=3.3.0 <4.0.0"
+  flutter: ">=3.18.0-18.0.pre.54"

--- a/test/json_decoder_test.dart
+++ b/test/json_decoder_test.dart
@@ -1,3 +1,4 @@
+import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
 
 import 'package:flutter_json_view/src/utils/utils.dart';
@@ -75,8 +76,9 @@ void convertMapTest(int index, String jsonString, {bool valid = true}) {
   test(
     'Test jsonStringToObject Map #$index',
     () {
-      final isMap =
-          JsonConverter.jsonStringToObject(jsonString) is Map<String, dynamic>;
+      final isMap = JsonConverter.jsonStringToObject(
+              jsonString, const Text("Failed to process string"))
+          is Map<String, dynamic>;
       expect(isMap, valid);
     },
   );
@@ -86,7 +88,8 @@ void convertListTest(int index, String jsonString, {bool valid = true}) {
   test(
     'Test jsonStringToObject List #$index',
     () {
-      final isMap = JsonConverter.jsonStringToObject(jsonString) is List;
+      final isMap = JsonConverter.jsonStringToObject(
+          jsonString, const Text("Failed to process List")) is List;
       expect(isMap, valid);
     },
   );


### PR DESCRIPTION
When passing something not JSON, the assert in the converter will throw an exception.

It seemed much cleaner to me, to instead have it return an Error widget that the developer can style themselves.

Disclaimer: was unable to test if it all works as intended