### PR TITLE
move flutter_lints to dev_dependencies

### DIFF
--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -17,8 +17,8 @@ environment:
 dependencies:
   flutter:
     sdk: flutter
-  flutter_lints: ">=2.0.0 <4.0.0"
 
 dev_dependencies:
   flutter_test:
     sdk: flutter
+  flutter_lints: ">=2.0.0 <4.0.0"


### PR DESCRIPTION
There should be no reason to add `flutter_lints` as dependency instead of a `dev_dependencies`.